### PR TITLE
feat!: replace buggy Flask interface with AWS API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ Scroll down a bit and click Pinecone. Follow the Guide here to setup the rest of
 1. Run `cdk bootstrap` to setup the project for deployment.
 2. Deploy to lambda by running `cdk deploy`.
 3. If `cdk deploy` fails due to insufficient privileges to run docker, type `sudo cdk deploy`. If that doesn't work, type `sudo -i` to become root, `cd` back to the project root and run `cdk deploy` again.
-4. If successful, `cdk deploy` should have this: `DiscordBotLambdaStack.FunctionUrl = <your lambda function url>` in the output.
-5. Copy the Lambda Function URL and go to your Discord Developer's Portal (discord.dev). Set this as Interactions Endpoint for your Bot.
+4. If successful, `cdk deploy` should have this: `DiscordBotLambdaTest.ApiGatewayUrl = <Your API Gateway URL>` in the output.
+5. Copy the API Gateway URL and go to your Discord Developer's Portal (discord.dev). Set this as Interactions Endpoint for your Bot.
 ![image](https://github.com/UMLCloudComputing/rowdybot/assets/136134023/6e0171af-3151-4223-9590-b7d9953aca39)
 
 

--- a/cdk/discord-bot-lambda-stack.ts
+++ b/cdk/discord-bot-lambda-stack.ts
@@ -28,7 +28,7 @@ export class DiscordBotLambdaStack extends cdk.Stack {
       }
     );
 
-    const api = new apigateway.LambdaRestApi(this, 'HelloWorldApi', {
+    const api = new apigateway.LambdaRestApi(this, `InteractionsAPI${id}`, {
       handler: dockerFunction,
       proxy: true,
     });

--- a/cdk/discord-bot-lambda-stack.ts
+++ b/cdk/discord-bot-lambda-stack.ts
@@ -16,7 +16,7 @@ export class DiscordBotLambdaStack extends cdk.Stack {
       {
         code: lambda.DockerImageCode.fromImageAsset("./src"),
         memorySize: 1024,
-        timeout: cdk.Duration.seconds(10),
+        timeout: cdk.Duration.seconds(600),
         architecture: lambda.Architecture.X86_64,
         environment: {
           DISCORD_PUBLIC_KEY: process.env.DISCORD_PUBLIC_KEY ?? (() => { throw new Error("DISCORD_PUBLIC_KEY is not set"); })(),

--- a/cdk/discord-bot-lambda-stack.ts
+++ b/cdk/discord-bot-lambda-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import 'dotenv/config';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
 
 require('dotenv').config()
 
@@ -27,6 +28,11 @@ export class DiscordBotLambdaStack extends cdk.Stack {
       }
     );
 
+    const api = new apigateway.LambdaRestApi(this, 'HelloWorldApi', {
+      handler: dockerFunction,
+      proxy: true,
+    });
+
     const functionUrl = dockerFunction.addFunctionUrl({
       authType: lambda.FunctionUrlAuthType.NONE,
       cors: {
@@ -39,5 +45,9 @@ export class DiscordBotLambdaStack extends cdk.Stack {
     new cdk.CfnOutput(this, "FunctionUrl", {
       value: functionUrl.url,
     });
+
+    new cdk.CfnOutput(this, "ApiGatewayUrl", {
+      value: api.url,
+    }); 
   }
 }


### PR DESCRIPTION
Flask has caused numerous errors to fill the logs, despite the bot working completely fine. Secondly, Flask requires two compatibility layers in order to work with AWS Lambda.

By using AWS API Gateway, we improve Discord API call performance and reduce the errors that end up in the logs to ease development.